### PR TITLE
Refactor generateGoogleQR to expose base32 and url generation

### DIFF
--- a/lib/2FA.js
+++ b/lib/2FA.js
@@ -7,7 +7,7 @@ var TFA = module.exports = {};
 // get a base36 crypto secure key
 TFA.generateKey = function(length, cb) {
   if (!cb && typeof length === 'function') {
-    cb = opts;
+    cb = length;
     length = 20;
   }
 
@@ -94,6 +94,15 @@ TFA.generateCode = function(key, counter, opts) {
   return ourCode;
 };
 
+TFA.base32Encode = function (key) {
+  return base32.encode(key).toString().replace(/=/g, '');
+};
+
+TFA.generateUrl = function (name, account, key) {
+  return 'otpauth://totp/' + encodeURIComponent(account)
+           + '?issuer=' + encodeURIComponent(name)
+           + '&secret=' + TFA.base32Encode(key);
+};
 
 TFA.generateGoogleQR = function(name, account, key, opts, cb) {
   if (!cb && typeof opts === 'function') {
@@ -101,10 +110,7 @@ TFA.generateGoogleQR = function(name, account, key, opts, cb) {
     opts = {};
   }
 
-  var data = 'otpauth://totp/' + encodeURIComponent(account)
-              + '?issuer=' + encodeURIComponent(name)
-              + '&secret=' + base32.encode(key).toString().replace(/=/g, '');
-
+  var data = TFA.generateUrl(name, account, key);
 
   var formatter = function(buf) {
     switch(opts.encoding) {


### PR DESCRIPTION
This PR refactors the `generateGoogleQR` method to expose functions `base32Encode` and `generateUrl`.  This allows the consumer more control over how to provide the secret and URL to the end user.

For example, now it's possible to provide the base32 encoded secret for manual entry in the Google Authenticator app.

Resolves issue #1.
